### PR TITLE
Fix for Express 4.0.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,8 @@ var express = require('express')
  */
   
 module.exports =
-express.HTTPServer.prototype.controllers =
-express.HTTPSServer.prototype.controllers = function(app){
+express.application.controllers =
+express.application.controllers = function(app){
   var loaded = []
     , self = app || this
     , controllerPath = self.set('controllers path') || __dirname + '/../../controllers';

--- a/index.js
+++ b/index.js
@@ -26,7 +26,6 @@ var express = require('express')
  */
   
 module.exports =
-express.application.controllers =
 express.application.controllers = function(app){
   var loaded = []
     , self = app || this


### PR DESCRIPTION
Attach controllers to express.application instead of HTTPServer.
